### PR TITLE
Fixed overriding extra header's sub protocol

### DIFF
--- a/lib/transport/ws.ex
+++ b/lib/transport/ws.ex
@@ -9,7 +9,7 @@ defmodule Janus.Transport.WS do
   * `opts` - arbitrary options specific to adapters
 
   `opts` param will be extended with `extra_headers` field containing `Sec-WebSocket-Protocol` header
-  necessary to connect with Janus Gateway via WebSocket.
+  necessary to connect with Janus Gateway via WebSocket only if given header has not been previously specified.
 
   ## Example
       # This example uses `EchoAdapter` from `Janus.Transport.WS.Adapter` example.
@@ -42,7 +42,13 @@ defmodule Janus.Transport.WS do
 
     opts =
       opts
-      |> Keyword.update(:extra_headers, [janus_protocol], &[janus_protocol | &1])
+      |> Keyword.update(:extra_headers, [janus_protocol], fn headers ->
+        if List.keymember?(headers, "Sec-WebSocket-Protocol", 0) do
+          headers
+        else
+          [janus_protocol | headers]
+        end
+      end)
 
     with {:ok, connection} <- adapter.connect(url, self(), opts) do
       {:ok, state(connection: connection, adapter: adapter)}


### PR DESCRIPTION
Now passing extra headers to WebSocket transport `connect` function when "Sec-WebSocket-Protocol" header is already set headers will not be appended with default **"janus-protocol**" and provided protocol will be used instead. It is required when someone needs to use **"janus-admin-protocol"** to connect with janus gateway's admin api. 