### PR TITLE
Fix handle_info stop tuple

### DIFF
--- a/lib/adapters/gun.ex
+++ b/lib/adapters/gun.ex
@@ -100,20 +100,13 @@ if Code.ensure_loaded?(:gun) do
     end
 
     def handle_info(
-          {:gun_down, _, _, reason, _, _},
-          %State{receiver: receiver} = state
-        ) do
-      notify_status(receiver, {:disconnected, reason})
-      {:stop, state}
-    end
-
-    def handle_info(
-          {:gun_error, conn, _ref, reason},
+          {message, conn, _ref, reason},
           %State{connection: conn, receiver: receiver} = state
-        ) do
+        )
+        when message in [:gun_down, :gun_error] do
       notify_status(receiver, {:disconnected, reason})
       :ok = :gun.close(conn)
-      {:stop, state}
+      {:stop, {:disconnected, reason}, state}
     end
 
     def handle_info({:gun_error, conn, reason}, state) do


### PR DESCRIPTION
Fixes error with invalid return value from `handle_info`
I've also unified 2 clauses for `:gun_down` and  `:gun_error` as after down message gun may still reconnect, so closing makes sense