### PR TITLE
Add missing gun down matching

### DIFF
--- a/lib/adapters/gun.ex
+++ b/lib/adapters/gun.ex
@@ -113,6 +113,13 @@ if Code.ensure_loaded?(:gun) do
       handle_info({:gun_error, conn, nil, reason}, state)
     end
 
+    def handle_info(
+          {:gun_down, conn, _protocol, reason, _killed_streams, _unprocessed_streams},
+          state
+        ) do
+      handle_info({:gun_down, conn, nil, reason}, state)
+    end
+
     defp create_ws_connection([protocol, host, port, path], timeout, %{
            extra_headers: extra_headers
          }) do

--- a/lib/transport/ws.ex
+++ b/lib/transport/ws.ex
@@ -21,7 +21,7 @@ defmodule Janus.Transport.WS do
       iex> {:state, connection, EchoAdapter} = state
       iex> EchoAdapter.disconnect(connection)
       iex> msg = receive do msg -> msg end
-      iex> {:stop, {:disconnected, _}, state} = WS.handle_info(msg, state)
+      iex> {:error, {:disconnected, _}, state} = WS.handle_info(msg, state)
   """
 
   # TODO: instead of passing sec protocol inside `extra_headers` field to the adapter add an explicit `protocols` option
@@ -78,7 +78,7 @@ defmodule Janus.Transport.WS do
 
   @impl true
   def handle_info({:disconnected, connection_map}, state) do
-    {:stop, {:disconnected, connection_map}, state}
+    {:error, {:disconnected, connection_map}, state}
   end
 
   def handle_info({:ws_frame, frame}, state) do
@@ -90,7 +90,7 @@ defmodule Janus.Transport.WS do
           "[ #{__MODULE__} ] failed to parse incoming frame with reason: #{inspect(reason)}"
         )
 
-        {:stop, {:parse_failed, frame, reason}, state}
+        {:error, {:parse_failed, frame, reason}, state}
     end
   end
 

--- a/test/adapters/gun_test.exs
+++ b/test/adapters/gun_test.exs
@@ -28,7 +28,7 @@ defmodule Janus.Transport.WS.Adapters.GunTest do
     end
 
     test "connect with working remote server" do
-      assert {:ok, connection} = Gun.connect(@url, self(), [])
+      assert {:ok, _connection} = Gun.connect(@url, self(), [])
     end
 
     test "return error on invalid url" do
@@ -69,7 +69,7 @@ defmodule Janus.Transport.WS.Adapters.GunTest do
 
     test "stop on adapter disconnected message" do
       msg = {:disconnected, "disconnect"}
-      {:stop, {:disconnected, _}, _} = WS.handle_info(msg, %{})
+      {:error, {:disconnected, _}, _} = WS.handle_info(msg, %{})
     end
 
     test "send and receive back message from adapter", %{state: state} do
@@ -78,7 +78,7 @@ defmodule Janus.Transport.WS.Adapters.GunTest do
       assert {:ok, state} = WS.send(payload, 0, state)
       assert_receive {:ws_frame, _} = msg
 
-      assert {:ok, ^payload, state} = WS.handle_info(msg, state)
+      assert {:ok, ^payload, _state} = WS.handle_info(msg, state)
     end
 
     test "not send invalid data format via adapter", %{state: state} do

--- a/test/adapters/websockex_test.exs
+++ b/test/adapters/websockex_test.exs
@@ -27,7 +27,7 @@ defmodule Janus.Transport.WS.Adapters.WebSockexTest do
     end
 
     test "connect with working remote server" do
-      assert {:ok, connection} = Adapters.WebSockex.connect(@url, self(), [])
+      assert {:ok, _connection} = Adapters.WebSockex.connect(@url, self(), [])
     end
 
     test "return error on invalid url" do
@@ -70,7 +70,7 @@ defmodule Janus.Transport.WS.Adapters.WebSockexTest do
 
     test "stop on adapter disconnected message" do
       msg = {:disconnected, "disconnect"}
-      {:stop, {:disconnected, _}, _} = WS.handle_info(msg, %{})
+      assert {:error, {:disconnected, _}, _} = WS.handle_info(msg, %{})
     end
 
     test "send and receive back message from adapter", %{state: state} do
@@ -79,7 +79,7 @@ defmodule Janus.Transport.WS.Adapters.WebSockexTest do
       assert {:ok, state} = WS.send(payload, 0, state)
       assert_receive {:ws_frame, _} = msg
 
-      assert {:ok, ^payload, state} = WS.handle_info(msg, state)
+      assert {:ok, ^payload, _state} = WS.handle_info(msg, state)
     end
 
     test "not send invalid data format via adapter", %{state: state} do

--- a/test/transport/transport_test.exs
+++ b/test/transport/transport_test.exs
@@ -11,7 +11,7 @@ defmodule TransportTest do
 
   describe "connect should" do
     test "return ok on valid connection" do
-      assert {:ok, {:state, connection, @adapter}} = WS.connect({@fake_url, @adapter, []})
+      assert {:ok, {:state, _connection, @adapter}} = WS.connect({@fake_url, @adapter, []})
     end
 
     test "return an error on adapter failure" do


### PR DESCRIPTION
Added missing `gun_down` message pattern matching and changed `Janus.Transport.WS.handle_info/2` to return `{:error, reason, state}` tuple instead of `{:stop, reason, state}` to match with `Janus.Transport`. 